### PR TITLE
Fix sed & bash compatibility

### DIFF
--- a/what.py
+++ b/what.py
@@ -287,7 +287,7 @@ def show_function(command):
         commands = ' | '.join([
             "shopt -s extglob; . %s; %s %s" % (
                 get_options().functions, Bash.declare_f, command),
-            "sed '1 i#! /bin/bash\n'",
+            "sed '1 i\\\n#! /usr/bin/env bash\n'",
             Bash.view_file
         ])
         show_output_of_shell_command(commands)

--- a/what.sh
+++ b/what.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 # This script is intended to be sourced, not run
 if [[ $0 == $BASH_SOURCE ]]; then


### PR DESCRIPTION
- Use sed command compatible with BSD & GNU sed
- Don't assume /bin/bash path, use /usr/bin/env to locate

Before fix:
```shell
$ w what

Traceback (most recent call last):
  File "/Users/tim/code/what/what.py", line 477, in <module>
    sys.exit(main(args))
  File "/Users/tim/code/what/what.py", line 467, in main
    result |= show_command(arg)
  File "/Users/tim/code/what/what.py", line 391, in show_command
    show(command)
  File "/Users/tim/code/what/what.py", line 293, in show_function
    show_output_of_shell_command(commands)
  File "/Users/tim/code/what/what.py", line 97, in show_output_of_shell_command
    stdout: %s''' % (command, process.returncode, stderr, stdout))
__main__.BashError:
        command: "shopt -s extglob; . /tmp/functions; declare -f what | sed '1 i#! /bin/bash\n' | /usr/local/bin/vimcat"
        status: 0
        stderr: sed: 1: "1 i#! /bin/bash
": command i expects \ followed by text

        stdout:
Not found "what"
```

After fix:
```shell
$ w what
#! /usr/bin/env bash
what ()
{
    local __doc__='find what will be executed for a command string';
    PATH_TO_ALIASES=/tmp/aliases;
    PATH_TO_FUNCTIONS=/tmp/functions;
    alias > $PATH_TO_ALIASES;
    declare -f > $PATH_TO_FUNCTIONS;
    python $WHAT_DIR/what.py --aliases=$PATH_TO_ALIASES --functions=$PATH_TO_FUNCTIONS "$@";
    local return_value=$?;
    rm -f $PATH_TO_ALIASES;
    rm -f $PATH_TO_FUNCTIONS;
    return $return_value
}
```

I've tested this with latest gnu-sed and with OS X's BSD sed.