### PR TITLE
Include `=` when matching aliases' definitions

### DIFF
--- a/what.sh
+++ b/what.sh
@@ -214,8 +214,8 @@ _edit_alias () {
     OLD_IFS=$IFS
     IFS=:; for sourced_file in $SOURCED_FILES
     do
-        if grep -q "alias $1" $sourced_file; then
-            $EDITOR $sourced_file +/"alias $1"
+        if grep -q "alias $1=" $sourced_file; then
+            $EDITOR $sourced_file +/"alias $1="
         fi
     done
     IFS=$OLD_IFS


### PR DESCRIPTION
This fixes the scenario where an alias exists who's name starts with
another alias' name:

alias foo_bar=1
alias foo=2

When editing the alias 'foo', the curser will be placed on the first
alias instead of the second.
This commit includes the '=' in the match, so 'we foo' will search for
'foo=' and will thus not match the 'foo_bar' alias anymore.

Before:
![Before](https://www.dropbox.com/s/dnn0iy3ijco3rgm/Screenshot%202015-06-17%2021.08.08.png?dl=1)

After:
![After](https://www.dropbox.com/s/hfak8zuaw289dt4/Screenshot%202015-06-17%2021.06.36.png?dl=1)