### PR TITLE
Improved alias matching for 'we' command

### DIFF
--- a/what.sh
+++ b/what.sh
@@ -214,8 +214,9 @@ _edit_alias () {
     OLD_IFS=$IFS
     IFS=:; for sourced_file in $SOURCED_FILES
     do
-        if grep -q "alias $1" $sourced_file; then
-            $EDITOR $sourced_file +/"alias $1"
+        line_number=$(grep -nF "alias $1=" $sourced_file | cut -d ':' -f1)
+        if [[ -n "$line_number" ]]; then
+            $EDITOR $sourced_file +$line_number
         fi
     done
     IFS=$OLD_IFS


### PR DESCRIPTION
- Fix accidentally matching regexs
  E.g. aliases containing "." would match any charactor instead of a
  literal "."
- Fix opening the file on the correct line
  E.g. if there's two aliases like:

      alias foo_bar=1
      alias foo=2
  and "we foo" is run, it would open the editor on the "foo_bar" alias,
  instead of on "foo".
- Fix making the editor do a string search, now we do that with grep
  and jump straight to the correct line.

Before:
![Before](https://www.dropbox.com/s/dnn0iy3ijco3rgm/Screenshot%202015-06-17%2021.08.08.png?dl=1)

After:
![After](https://www.dropbox.com/s/6sd8h03mcfwrbee/Screenshot%202015-06-17%2021.28.45.png?dl=1)

This is an improvement on #2